### PR TITLE
Feature/nav 167 move implementation to project management

### DIFF
--- a/Writerside/d.tree
+++ b/Writerside/d.tree
@@ -9,8 +9,11 @@
     <toc-element topic="introduction.md"/>
     <toc-element topic="interim-review.md"/>
     <toc-element topic="project-management.md">
-        <toc-element topic="methodology.md"/>
+        <toc-element topic="software-development-process.md"/>
         <toc-element topic="outline.md"/>
+        <toc-element topic="code-style-guide.md"/>
+        <toc-element topic="git-best-practices.md"/>
+        <toc-element topic="release.md"/>
     </toc-element>
     <toc-element topic="analysis.md">
         <toc-element topic="use-case.md"/>
@@ -29,8 +32,13 @@
         <toc-element topic="system-context.md"/>
     </toc-element>
     <toc-element topic="implementation.md">
-        <toc-element topic="git-best-practices.md"/>
-        <toc-element topic="code-style-guide.md"/>
-        <toc-element topic="release.md"/>
+        <toc-element topic="simple-raptor.md"/>
+        <toc-element topic="extended-raptor.md"/>
+        <toc-element topic="raptor-xx.md"/>
     </toc-element>
+    <toc-element topic="results-and-discussion.md">
+        <toc-element topic="benchmarking.md"/>
+        <toc-element topic="limitations.md"/>
+    </toc-element>
+    <toc-element topic="conclusion-and-outlook.md"/>
 </instance-profile>

--- a/Writerside/d.tree
+++ b/Writerside/d.tree
@@ -37,6 +37,7 @@
         <toc-element topic="raptor-xx.md"/>
     </toc-element>
     <toc-element topic="results-and-discussion.md">
+        <toc-element topic="deployment.md"/>
         <toc-element topic="benchmarking.md"/>
         <toc-element topic="limitations.md"/>
     </toc-element>

--- a/Writerside/redirection-rules.xml
+++ b/Writerside/redirection-rules.xml
@@ -78,4 +78,12 @@
         <description>Created after removal of "Terminology" from Naviqore</description>
         <accepts>terminology.html</accepts>
     </rule>
+    <rule id="6e42795d">
+        <description>Created after removal of "Raptor Implementation" from Naviqore</description>
+        <accepts>raptor-implementation.html</accepts>
+    </rule>
+    <rule id="6ac20ec2">
+        <description>Created after removal of "Trip Mask Provider" from Naviqore</description>
+        <accepts>trip-mask-provider.html</accepts>
+    </rule>
 </rules>

--- a/Writerside/topics/benchmarking.md
+++ b/Writerside/topics/benchmarking.md
@@ -1,0 +1,3 @@
+# Benchmarking
+
+Start typing here...

--- a/Writerside/topics/conclusion-and-outlook.md
+++ b/Writerside/topics/conclusion-and-outlook.md
@@ -1,0 +1,3 @@
+# Conclusion and Outlook
+
+Start typing here...

--- a/Writerside/topics/deployment.md
+++ b/Writerside/topics/deployment.md
@@ -6,7 +6,7 @@ Raptor algorithm, along with a simple viewer.
 ## Configuration
 
 The configuration of the public transit service is best handled through environment variables. This approach
-provides flexibility and allows for easier management across different environments, such as development, and
+provides flexibility and allows for easier management across different environments, such as development and
 production. Below are some of the key environment variables that are essential for configuring the router:
 
 - **GTFS_STATIC_URI**: URL or file path to a static GTFS feed. The service will initially fetch the GTFS from this URL.

--- a/Writerside/topics/deployment.md
+++ b/Writerside/topics/deployment.md
@@ -1,19 +1,66 @@
 # Deployment
 
-Deployment of the public transit service, based on GTFS and the extended raptor, and viewer.
+Deployment of the complete Naviqore system, which consists of a public transit service based on GTFS and the extended
+Raptor algorithm, along with a simple viewer.
 
 ## Configuration
 
-TODO: Describe application.properties
+The configuration of the public transit service is best handled through environment variables. This approach
+provides flexibility and allows for easier management across different environments, such as development, and
+production. Below are some of the key environment variables that are essential for configuring the router:
+
+- **GTFS_STATIC_URI**: URL or file path to a static GTFS feed. The service will initially fetch the GTFS from this URL.
+  If the provided value is a file path, the GTFS is loaded from the file and the update interval is ignored.
+  Example for Switzerland: `https://opentransportdata.swiss/en/dataset/timetable-2024-gtfs2020/permalink`
+
+- **GTFS_STATIC_UPDATE_CRON**: Cron expression for updating the static GTFS feed from the provided URL. Public transit
+  agencies update their static GTFS data regularly. Set this interval to match the agency's publish schedule. Default is
+  to update the schedule daily at 4 AM.
+
+- **TRANSFER_TIME_SAME_STOP_DEFAULT**: Default transfer time between same stop transfers in seconds. If GTFS already
+  provides same stop transfer times, those have precedence over this default. If the value is set to 0, no additional
+  same stop transfer times are set.
+
+- **TRANSFER_TIME_BETWEEN_STOPS_MINIMUM**: Minimum transfer time between the different stops in seconds. If stops are
+  closer than this, this time has precedence over the actual walking time, which accounts for leaving the station
+  building, stairways, etc. If GTFS already provides a transfer time between two stops, the GTFS time has precedence
+  over this minimum. If the value is set to -1, no additional transfers will be created.
+
+- **TRANSFER_TIME_ACCESS_EGRESS**: Time in seconds required to access or egress from a public transit trip. This time is
+  added twice to the walking duration of transfers between two stops and once to first and last mile walking legs.
+
+- **WALKING_SEARCH_RADIUS**: Search radius in meters. No walks with a longer beeline distance between origin and
+  destination will appear in connections (first/last mile and between stop transfers). The actual distance of the walk
+  might be longer. Note: This radius is also used to generate same stop transfers.
+
+- **WALKING_SPEED**: Walking speed in meters per second. The default value is based on the average preferred walking
+  speed.
+
+- **WALKING_DURATION_MINIMUM**: Minimum walking duration in seconds. If the walking duration, without access or egress
+  time (see 'TRANSFER_TIME_ACCESS_EGRESS'), is shorter, no first or last mile walk is needed to reach the location. This
+  avoids very short walks inside stations that give a false sense of accuracy.
+
+- **RAPTOR_DAYS_TO_SCAN**: Number of dates surrounding the queried date should be included in the scan. This is useful
+  if the previous GTFS service day includes trips on the queried date. Or the connection is so long that it continues
+  into the next service day. The default value is 3, which includes the previous, current, and next service day.
+
+- **RAPTOR_RANGE**: Maximum range in seconds to identify departures or arrivals for scanning in order to reduce the
+  travel time (a.k.a. range Raptor). Values smaller than 1 are allowed and imply using the standard Raptor algorithm.
+  The default value is -1, which means no range.
+
+For further configuration settings, such as those related to caching, logging, and application management, please refer
+directly to
+the [application.properties](https://github.com/naviqore/public-transit-service/blob/main/src/main/resources/application.properties)
+file.
 
 ## Helm Chart
 
-TODO: Describe helm chart
+This [Helm chart](https://github.com/naviqore/deployment) defines the Kubernetes resources required to deploy the
+service and viewer in the cloud. The public transit service can be configured by overriding the default environment
+variables via Helm's values mechanism.
 
-## Docker compose
+## Docker Compose
 
-TODO: Describe docker compose setup
-
-## References
-
-TODO: Add link to Github repository.
+This [Docker Compose](https://github.com/naviqore/deployment/blob/main/docker-compose.yml) setup provides an alternative
+method to deploy the service and viewer, particularly suited for local development. To configure the routing service,
+the environment variables should be adjusted within the Docker Compose file.

--- a/Writerside/topics/deployment.md
+++ b/Writerside/topics/deployment.md
@@ -1,0 +1,19 @@
+# Deployment
+
+Deployment of the public transit service, based on GTFS and the extended raptor, and viewer.
+
+## Configuration
+
+TODO: Describe application.properties
+
+## Helm Chart
+
+TODO: Describe helm chart
+
+## Docker compose
+
+TODO: Describe docker compose setup
+
+## References
+
+TODO: Add link to Github repository.

--- a/Writerside/topics/extended-raptor.md
+++ b/Writerside/topics/extended-raptor.md
@@ -1,0 +1,15 @@
+# Extended Raptor
+
+## Latest Departure
+
+Routing in negative timeline direction.
+
+## Multiday
+
+Adjustments to trip mask provider.
+
+## Range Raptor
+
+## Accessibility and Bike Information
+
+## Caching

--- a/Writerside/topics/implementation.md
+++ b/Writerside/topics/implementation.md
@@ -1,5 +1,5 @@
 # Implementation
 
-- [Git Best Practices](git-best-practices.md)
-- [Code Style Guide](code-style-guide.md)
-- [Release](release.md)
+- [Simple Raptor](simple-raptor.md)
+- [Extended Raptor](extended-raptor.md)
+- [RaptorXX](raptor-xx.md)

--- a/Writerside/topics/limitations.md
+++ b/Writerside/topics/limitations.md
@@ -1,0 +1,3 @@
+# Limitations
+
+Start typing here...

--- a/Writerside/topics/outline.md
+++ b/Writerside/topics/outline.md
@@ -1,6 +1,6 @@
 # Outline
 
-## Project milestones
+## Project Milestones
 
 ```mermaid
 gantt
@@ -35,7 +35,7 @@ gantt
         Design: 2024-08-15, 2024-09-01
         Implementation: 2024-08-15, 2024-09-15
         Testing: 2024-08-15, 2024-09-15
-        Supervisor-Sync (tbd.): milestone, 2024-09-15, 0d
+        Supervisor-Sync (on Site): milestone, 2024-09-13, 0d
     section v1.0.0
         Continuous Documentation: 2024-04-15, 2024-09-27
         Thesis: 2024-08-15, 2024-09-27
@@ -45,7 +45,9 @@ gantt
 
 ```
 
-## Team resource schedule
+## Team Resource Schedule
+
+TODO: Replace with actual logged times from JIRA.
 
 [Link to time schedule](https://docs.google.com/spreadsheets/d/1NVJV-sXO0yzrbKqA5deLzzR0VaGW3y-0jaoxKCRQ4sk/edit?usp=sharing)
 
@@ -64,5 +66,3 @@ gantt
 | KW     | Calendar Week                       |
 | V🌴    | Vacation                            |
 | Total  | Sum of time estimates for all weeks |
-
-Start typing here...

--- a/Writerside/topics/project-management.md
+++ b/Writerside/topics/project-management.md
@@ -1,4 +1,7 @@
 # Project Management
 
-- [Methodology](methodology.md)
+- [Software Development Process](software-development-process.md)
 - [Outline](outline.md)
+- [Git Best Practices](git-best-practices.md)
+- [Code Style Guide](code-style-guide.md)
+- [Release](release.md)

--- a/Writerside/topics/raptor-xx.md
+++ b/Writerside/topics/raptor-xx.md
@@ -1,0 +1,3 @@
+# RaptorXX
+
+Implementation of the simple Raptor in C++ for performance comparison in benchmarking.

--- a/Writerside/topics/results-and-discussion.md
+++ b/Writerside/topics/results-and-discussion.md
@@ -1,0 +1,4 @@
+# Results and Discussion
+
+- [Benchmarking](benchmarking.md)
+- [Limitations](limitations.md)

--- a/Writerside/topics/results-and-discussion.md
+++ b/Writerside/topics/results-and-discussion.md
@@ -1,4 +1,5 @@
 # Results and Discussion
 
+- [Deployment](deployment.md)
 - [Benchmarking](benchmarking.md)
 - [Limitations](limitations.md)

--- a/Writerside/topics/simple-raptor.md
+++ b/Writerside/topics/simple-raptor.md
@@ -1,0 +1,5 @@
+# Simple Raptor
+
+## Stop Times Array
+
+## Trip Mask Provider

--- a/Writerside/topics/software-development-process.md
+++ b/Writerside/topics/software-development-process.md
@@ -1,6 +1,4 @@
-# Methodology
-
-## Software Development Process
+# Software Development Process
 
 The development process follows an iterative Scrum-like setup with 4-week sprints between supervisor meetings. Task
 management and monitoring are facilitated using the agile project tracking software, Jira. This structured way of
@@ -48,7 +46,7 @@ The fail-fast concept is preferred in development. Given the complexity of the p
 identification and resolution of issues, ensuring a more efficient development process.
 
 Clean code principles are followed, and all code is reviewed by team members. For more details, refer to
-the [Code Style Section](requirements.md).
+the [Code Style Section](code-style-guide.md).
 
 ## Documentation
 


### PR DESCRIPTION
Suggestion for the thesis content.

Adjust section `Implementation`: Contains now simple-raptor, extended-raptor and simple-raptor-cxx

Add sections: `Results and Discussion`, `Conclusion and Outlook`